### PR TITLE
Fix issue #10 properly for front camera opening by default instead of back camera

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ allprojects {
 
 ext {
     sdk = 25
-    buildTools = "24.0.3"
+    buildTools = "25.0.2"
     minSdk = 10
     libraryVersion = "1.0.3"
     supportVersion = "25.1.0"

--- a/camerafragment/src/main/java/com/github/florent37/camerafragment/internal/controller/impl/Camera1Controller.java
+++ b/camerafragment/src/main/java/com/github/florent37/camerafragment/internal/controller/impl/Camera1Controller.java
@@ -113,7 +113,7 @@ public class Camera1Controller implements CameraController<Integer>,
         final Integer frontCameraId = cameraManager.getFaceFrontCameraId();
         final Integer currentCameraId = cameraManager.getCurrentCameraId();
 
-        if (cameraFace == Configuration.CAMERA_FACE_REAR && backCameraId != null && !backCameraId.equals(currentCameraId)) {
+        if (cameraFace == Configuration.CAMERA_FACE_REAR && backCameraId != null) {
             setCurrentCameraId(backCameraId);
             cameraManager.closeCamera(this);
         } else if (frontCameraId != null && !frontCameraId.equals(currentCameraId)) {


### PR DESCRIPTION
* Also update build tools to 25.0.2

This seems to be only an issue with `Camera1Controlller`

I think the real fix would be change the architecture with the methods `switchCamera` and `setCamera`

I would use a setCamera after hitting `switchCamera()`
`switchCamera()` would just call `setCamera(!currentCamera)` or something similar.

