### PR TITLE
stop making null File / NPE

### DIFF
--- a/camerafragment/src/main/java/com/github/florent37/camerafragment/internal/ui/BaseAnncaFragment.java
+++ b/camerafragment/src/main/java/com/github/florent37/camerafragment/internal/ui/BaseAnncaFragment.java
@@ -280,11 +280,6 @@ public abstract class BaseAnncaFragment<CameraId> extends Fragment implements Ca
     }
 
     @Override
-    public void takePhotoOrCaptureVideo(final CameraFragmentResultListener resultListener) {
-        takePhotoOrCaptureVideo(resultListener, null, null);
-    }
-
-    @Override
     public void takePhotoOrCaptureVideo(final CameraFragmentResultListener resultListener, @Nullable String directoryPath, @Nullable String fileName) {
         switch (currentMediaActionState) {
             case MediaAction.ACTION_PHOTO:


### PR DESCRIPTION
workaround to prevent generateStorageDir fail, which must be an issue with the context that's passed to it.
```shell
E/AndroidRuntime(26622): java.lang.NullPointerException
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.utils.CameraHelper.generateStorageDir(CameraHelper.java:85)
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.utils.CameraHelper.getOutputMediaFile(CameraHelper.java:96)
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.controller.impl.Camera1Controller.takePhoto(Camera1Controller.java:85)
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.ui.BaseAnncaFragment.takePhoto(BaseAnncaFragment.java:606)
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.ui.BaseAnncaFragment.takePhotoOrCaptureVideo(BaseAnncaFragment.java:291)
E/AndroidRuntime(26622): 	at com.github.florent37.camerafragment.internal.ui.BaseAnncaFragment.takePhotoOrCaptureVideo(BaseAnncaFragment.java:284)
E/AndroidRuntime(26622): 	at org.tricorder.modern.hopper.MainActivity$2.onClick(MainActivity.java:92)
```